### PR TITLE
Some Fixes

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -529,7 +529,7 @@
                 if (-not $PSBoundParameters.ContainsKey("TableName") -and
                     -not $PSBoundParameters.ContainsKey("TableStyle") -and
                     -not $AutoFilter) {
-                    $TableName = 'Table1'
+                    $TableName = ''
                 }
             }
             if ($ExcelPackage) {
@@ -629,8 +629,7 @@
                 Write-Warning "Table name $($InputObject.TableName) is not unique, adding '_' to it "
                 $InputObject.TableName += "_"
             }
-            if ($TableName -or $PSBoundParameters.ContainsKey("TableStyle")) {
-                $TableName = $null
+            if ($null -ne $TableName -or $PSBoundParameters.ContainsKey("TableStyle")) {
                 $null = $ws.Cells[$row,$StartColumn].LoadFromDataTable($InputObject, (-not $noHeader),$TableStyle )
             }
             else {
@@ -818,11 +817,10 @@
         if ($RangeName) { Add-ExcelName  -Range $ws.Cells[$dataRange] -RangeName $RangeName}
 
         #Allow table to be inserted by specifying Name, or Style or both; only process autoFilter if there is no table (they clash).
-        if     ($null -ne $TableName) {
-                   Add-ExcelTable -Range $ws.Cells[$dataRange] -TableName $PSBoundParameters['TableName'] -TableStyle $TableStyle
-        }
-        elseif ($PSBoundParameters.ContainsKey('TableStyle')) {
-                  Add-ExcelTable -Range $ws.Cells[$dataRange] -TableName "" -TableStyle $TableStyle
+        if     ($null -ne $TableName -or $PSBoundParameters.ContainsKey('TableStyle')) {
+            if ($InputObject -isnot [System.Data.DataTable]) {
+                Add-ExcelTable -Range $ws.Cells[$dataRange] -TableName $TableName -TableStyle $TableStyle
+            }
         }
         elseif ($AutoFilter) {
             try {

--- a/__tests__/Export-Excel.Tests.ps1
+++ b/__tests__/Export-Excel.Tests.ps1
@@ -614,7 +614,7 @@ Describe ExportExcel {
         $dataWs = $Excel.Workbook.Worksheets["NoOffset"]
 
         it "Created a new sheet and auto-extended a table and explicitly extended named ranges     " {
-            $dataWs.Tables["ProcTab"].Address.Address                   | Should     be "A1:E11"
+            $dataWs.Tables["ProcTab"].Address.Address                   | Should     be "A1:E21"
             $dataWs.Names["CPU"].Rows                                   | Should     be 20
             $dataWs.Names["CPU"].Columns                                | Should     be 1
         }


### PR DESCRIPTION
Export-Excel.ps1
532: Change back `'Table1'` to `''`, Now mode TableName is auto generated if not specified (shouldn't really matter, just in case there will be a conflict somehow).
632: Fix -DataTable "" to use the LoadFromDataTable style variant.
820: DataTable + -TableStyle without -TableName corruption fix (it was setting a table twice).
Also simplified even more by removing the extra `if` as `-TableName ""` and `-TableName $null` give the same results on Add-ExcelTable.

822: Change back to `-TableName $TableName` from `-TableName $PSBoundParameters['TableName']` as change broke "auto-extended a table and explicitly extended named ranges" also undo change in test as it was correct before (Export-Excel.Tests.ps1 617)